### PR TITLE
fix(#4): Add more tests for identifier parsing

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -18,6 +18,12 @@ mod tests {
 
     #[test]
     fn ident_parse_test() {
-        assert_eq!(lake_parser::ident("main"), Ok(Ident::new("main")))
+        assert_eq!(lake_parser::ident("main"), Ok(Ident::new("main")));
+        assert_eq!(lake_parser::ident("Main"), Ok(Ident::new("Main")));
+        assert_eq!(lake_parser::ident("_main"), Ok(Ident::new("_main")));
+        assert_eq!(lake_parser::ident("a_main"), Ok(Ident::new("a_main")));
+        assert_eq!(lake_parser::ident("A_main"), Ok(Ident::new("A_main")));
+        assert_eq!(lake_parser::ident("A_M"), Ok(Ident::new("A_M")));
+        assert_eq!(lake_parser::ident("AM"), Ok(Ident::new("AM")));
     }
 }


### PR DESCRIPTION
This commit adds more comprehensive tests to ensure that the identifier parser correctly handles various valid identifier names
Closes #4