### PR TITLE
fix(#6): Add basic CI workflow for running tests on pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: Cargo Tests
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run formatting check
+        run: cargo fmt --all -- --check
+
+      - name: Run linter
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Run tests
+        run: cargo test --lib --verbose

--- a/src/api/ast/mod.rs
+++ b/src/api/ast/mod.rs
@@ -1,8 +1,10 @@
+#[allow(dead_code)]
 pub struct Process {
     ident: String,
     branches: Vec<Branch>,
 }
 
+#[allow(dead_code)]
 pub struct Branch {
     ty: BranchType,
     variables: Vec<Variable>,
@@ -13,6 +15,7 @@ pub enum BranchType {
     Constructor,
 }
 
+#[allow(dead_code)]
 pub struct Variable {
     ident: Ident,
     ty: Path,


### PR DESCRIPTION
This commit introduces a basic CI workflow that runs cargo fmt, clippy, and tests on every pull request to the master branch. This helps ensure code quality and prevents regressions.

Closes #6