### PR TITLE
fix(#10): Add deny lints for unwraps

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,12 @@
+#![deny(
+    clippy::unwrap_used,
+    clippy::get_unwrap,
+    clippy::panicking_unwrap,
+    clippy::unwrap_in_result,
+    clippy::unnecessary_literal_unwrap,
+    clippy::unnecessary_unwrap,
+    clippy::or_then_unwrap
+)]
+
 pub mod api;
 pub(crate) mod parser;


### PR DESCRIPTION
This commit adds deny lints for all kinds of unwraps. This will help to avoid unexpected panics in production code
Closes #10