### PR TITLE
fix(#19): Replace Value enum with Literal enum

### DIFF
--- a/src/api/ast/mod.rs
+++ b/src/api/ast/mod.rs
@@ -19,19 +19,18 @@ pub enum BranchType {
 pub struct Variable {
     ident: Ident,
     ty: Path,
-    default: Option<Value>,
+    default: Option<Literal>,
 }
 
 impl Variable {
-    pub fn new(ident: Ident, ty: Path, default: Option<Value>) -> Self {
+    pub fn new(ident: Ident, ty: Path, default: Option<Literal>) -> Self {
         Self { ident, ty, default }
     }
 }
 
-pub enum Value {
-    Int(i32),
-    String(String),
-    Bool(bool),
+#[derive(Debug, PartialEq, PartialOrd)]
+pub enum Literal {
+    Number(String),
 }
 
 #[derive(Debug, PartialEq, PartialOrd)]

--- a/src/parser/ident/mod.rs
+++ b/src/parser/ident/mod.rs
@@ -8,12 +8,10 @@ use crate::{
     parser::parser_error::{ParserError, Result},
 };
 
-#[allow(dead_code)]
 pub fn is_ident_start(c: char) -> bool {
     c.is_alphabetic() || c == '_'
 }
 
-#[allow(dead_code)]
 pub fn is_ident_char(c: char) -> bool {
     c.is_alphanumeric() || c == '_'
 }
@@ -42,11 +40,13 @@ pub fn ident(input: &str) -> Result<(&str, Ident)> {
 
 #[cfg(test)]
 mod tests {
-    use miette::Result;
 
     use crate::{
         api::ast::Ident,
-        parser::{ident::ident, parser_error::ParserError},
+        parser::{
+            ident::ident,
+            parser_error::{ParserError, Result},
+        },
     };
 
     #[test]

--- a/src/parser/literal/mod.rs
+++ b/src/parser/literal/mod.rs
@@ -1,0 +1,1 @@
+pub mod number;

--- a/src/parser/literal/number/mod.rs
+++ b/src/parser/literal/number/mod.rs
@@ -1,0 +1,55 @@
+use nom::{AsChar, FindSubstring, IResult, Parser, bytes::complete::take_while1};
+
+use crate::{
+    api::ast::Literal,
+    parser::parser_error::{ParserError, Result},
+};
+
+#[allow(dead_code)]
+pub fn number(input: &str) -> Result<(&str, Literal)> {
+    let res: IResult<&str, &str> = take_while1(|ch: char| ch.is_dec_digit()).parse(input);
+    let (next, raw) = res.map_err(|err| match err {
+        nom::Err::Incomplete(needed) => todo!("{needed:?}"),
+        nom::Err::Error(error) => match input.find_substring(error.input) {
+            Some(start) => ParserError::NumberParsingError(
+                error.input.into(),
+                (start, error.input.len()).into(),
+            ),
+            None => ParserError::BadSubsting(error.input.into()),
+        },
+        nom::Err::Failure(remaining) => todo!("Failure: {remaining}"),
+    })?;
+    Ok((next, Literal::Number(raw.to_string())))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        api::ast::Literal,
+        parser::{
+            literal::number::number,
+            parser_error::{ParserError, Result},
+        },
+    };
+
+    #[test]
+    fn simple_number_test() -> Result<()> {
+        assert_eq!(number("123"), Ok(("", Literal::Number("123".into()))));
+        Ok(())
+    }
+
+    #[test]
+    fn not_only_number_test() -> Result<()> {
+        assert_eq!(number("40abs"), Ok(("abs", Literal::Number("40".into()))));
+        Ok(())
+    }
+
+    #[test]
+    fn not_number_test() -> Result<()> {
+        assert_eq!(
+            number("abs"),
+            Err(ParserError::NumberParsingError("abs".into(), (0, 3).into()))
+        );
+        Ok(())
+    }
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,2 +1,3 @@
 pub mod ident;
+pub mod literal;
 pub mod parser_error;

--- a/src/parser/parser_error/mod.rs
+++ b/src/parser/parser_error/mod.rs
@@ -16,7 +16,7 @@ pub enum ParserError {
     )]
     IdentParsingError(
         #[source_code] String,
-        #[label("Something wrong here")] SourceSpan,
+        #[label("Wrong ident here")] SourceSpan,
     ),
 
     #[error("Substring not found error")]
@@ -27,8 +27,17 @@ pub enum ParserError {
         )
     )]
     BadSubsting(String),
-}
 
+    #[error("Number parsing error")]
+    #[diagnostic(
+        code(parser::error::numberParsingError),
+        help("Expected a integer consisting only of digits (0–9).")
+    )]
+    NumberParsingError(
+        #[source_code] String,
+        #[label("Wrong number here")] SourceSpan,
+    ),
+}
 // impl<I> ParseError<I> for ParserError
 // where
 //     I: nom::Offset + ToString,


### PR DESCRIPTION
The Value enum was replaced by Literal enum.
Also the default value of the Variable struct was updated.

Closes #19